### PR TITLE
remove GOARCH=amd64 to prevent cross-compiling go binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ all: format generate build test
 build: operator prometheus-config-reloader
 
 operator:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+	GOOS=linux CGO_ENABLED=0 go build \
 	-ldflags "-X github.com/coreos/prometheus-operator/pkg/version.Version=$(shell cat VERSION)" \
 	-o $@ cmd/operator/main.go
 
 prometheus-config-reloader:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
+	GOOS=linux CGO_ENABLED=0 go build \
 	-ldflags "-X github.com/coreos/prometheus-operator/pkg/version.Version=$(shell cat VERSION)" \
 	-o $@ cmd/$@/main.go
 


### PR DESCRIPTION
Remove GOARCH=amd64 to prevent cross-compiling go binaries in ppc64le builds
cc: @sosiouxme 
