### PR TITLE
*: set -mod="vendor" to build OCP container image

### DIFF
--- a/Dockerfile.config-reloader.rhel
+++ b/Dockerfile.config-reloader.rhel
@@ -2,6 +2,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/coreos/prometheus-operator
 COPY . .
 ENV GO111MODULE=on
+ENV GOFLAGS="-mod=vendor"
 RUN make prometheus-config-reloader
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,8 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/coreos/prometheus-operator
 COPY . .
+ENV GO111MODULE=on
+ENV GOFLAGS="-mod=vendor"
 RUN make operator-no-deps
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base


### PR DESCRIPTION
OCP images should be able to be built without contacting external services.

This should fix recent OSBS build problems.

/cc @s-urbaniak

Related to https://github.com/openshift/k8s-prometheus-adapter/pull/17