### PR TITLE
Default ARCH/OS to current "go env" value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=/bin/bash -o pipefail
 
-OS?=linux
-ARCH?=amd64
+OS?=$(shell go env GOOS)
+ARCH?=$(shell go env GOARCH)
 
 GO_PKG=github.com/coreos/prometheus-operator
 REPO?=quay.io/coreos/prometheus-operator


### PR DESCRIPTION
When running the Makefile, if the ARCH or OS ARG is not specified we
should default to the current "go env" value rather than the default of
amd64/linux.