### PR TITLE
Bug 1834892: CARRY: allow building multi-arch prometheus-operator images downstream

### DIFF
--- a/Dockerfile.config-reloader.ocp
+++ b/Dockerfile.config-reloader.ocp
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/coreos/prometheus-operator
 COPY . .
 ENV GO111MODULE=on
 ENV GOFLAGS="-mod=vendor"
-RUN make prometheus-config-reloader
+RUN OS=$(go env GOOS) ARCH=$(go env GOARCH) make prometheus-config-reloader
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/coreos/prometheus-operator/prometheus-config-reloader /usr/bin/

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/coreos/prometheus-operator
 COPY . .
 ENV GO111MODULE=on
 ENV GOFLAGS="-mod=vendor"
-RUN make operator-no-deps
+RUN OS=$(go env GOOS) ARCH=$(go env GOARCH) make operator-no-deps
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/coreos/prometheus-operator/operator /usr/bin/


### PR DESCRIPTION
Bring back multi-arch support. The current implementation in v0.38.1 is incompatible with build system.

/cc @openshift/openshift-team-monitoring @andymcc 