### PR TITLE
Bug 1867510: fix CVP issues due to incorrect labels set

### DIFF
--- a/Dockerfile.config-reloader.ocp
+++ b/Dockerfile.config-reloader.ocp
@@ -1,5 +1,5 @@
 # Dockerfile used by OSBS and by prow CI.
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/coreos/prometheus-operator
 COPY . .
 ENV GO111MODULE=on
@@ -7,11 +7,13 @@ ENV GOFLAGS="-mod=vendor"
 RUN OS=$(go env GOOS) ARCH=$(go env GOARCH) make prometheus-config-reloader
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
+LABEL io.k8s.display-name="Prometheus config reloader" \
+      io.k8s.description="This component reloads a Prometheus server in a controlled and configurable way." \
+      io.openshift.tags="prometheus" \
+      summary="This component reloads a Prometheus server in a controlled and configurable way." \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
+
 COPY --from=builder /go/src/github.com/coreos/prometheus-operator/prometheus-config-reloader /usr/bin/
 # doesn't require a root user.
 USER 1001
 ENTRYPOINT ["/usr/bin/prometheus-config-reloader"]
-LABEL io.k8s.display-name="Prometheus config reloader" \
-      io.k8s.description="This component reloads a Prometheus server in a controlled and configurable way." \
-      io.openshift.tags="prometheus" \
-      maintainer="Frederic Branczyk <fbranczy@redhat.com>"

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,5 +1,5 @@
 # Dockerfile used by OSBS and by prow CI.
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.14 AS builder
 WORKDIR /go/src/github.com/coreos/prometheus-operator
 COPY . .
 ENV GO111MODULE=on
@@ -7,11 +7,13 @@ ENV GOFLAGS="-mod=vendor"
 RUN OS=$(go env GOOS) ARCH=$(go env GOARCH) make operator-no-deps
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
+LABEL io.k8s.display-name="Prometheus Operator" \
+      io.k8s.description="This component manages the lifecycle and configuration of a Prometheus monitoring server as well as Prometheus Alertmanager clusters." \
+      io.openshift.tags="prometheus" \
+      summary="This component manages the lifecycle and configuration of a Prometheus monitoring server as well as Prometheus Alertmanager clusters." \
+      maintainer="OpenShift Monitoring Team <team-monitoring@redhat.com>"
+
 COPY --from=builder /go/src/github.com/coreos/prometheus-operator/operator /usr/bin/
 # doesn't require a root user.
 USER 1001
 ENTRYPOINT ["/usr/bin/operator"]
-LABEL io.k8s.display-name="Prometheus Operator" \
-      io.k8s.description="This component manages the lifecycle and configuration of a Prometheus monitoring server as well as Prometheus Alertmanager clusters." \
-      io.openshift.tags="prometheus" \
-      maintainer="Frederic Branczyk <fbranczy@redhat.com>"


### PR DESCRIPTION
- Fixing maintainer label to end with @redhat.com as this is expected
- Overriding summary label as it is inherited from base image and results with an incorrect value
- explicit golang 1.14 usage
- rearranged Dockerfiles to be similar to other ones used by the team

/cc @openshift/openshift-team-monitoring