### PR TITLE
Updating prometheus-config-reloader builder & base images to be consistent with ART

### DIFF
--- a/Dockerfile.config-reloader.ocp
+++ b/Dockerfile.config-reloader.ocp
@@ -1,12 +1,12 @@
 # Dockerfile used by OSBS and by prow CI.
-FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.6 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/coreos/prometheus-operator
 COPY . .
 ENV GO111MODULE=on
 ENV GOFLAGS="-mod=vendor"
 RUN OS=$(go env GOOS) ARCH=$(go env GOARCH) make prometheus-config-reloader
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM registry.svc.ci.openshift.org/ocp/4.7:base
 LABEL io.k8s.display-name="Prometheus config reloader" \
       io.k8s.description="This component reloads a Prometheus server in a controlled and configurable way." \
       io.openshift.tags="prometheus" \


### PR DESCRIPTION
Updating prometheus-config-reloader builder & base images to be consistent with ART
Reconciling with https://github.com/openshift/ocp-build-data/tree/f66c03011773dc3755ad874fc691be612914d65f/images/prometheus-config-reloader.yml

If you have any questions about this pull request, please reach out to `@art-team` in the `#aos-art` coreos slack channel.

Depends on https://github.com/openshift/images/pull/44 . Allow it to merge and then run `/test all` on this PR.