### PR TITLE
operator: only wait for cert reloader if there was an error

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -431,15 +431,15 @@ func Main() int {
 		wg.Go(func() error {
 			t := time.NewTicker(cfg.ServerTLSConfig.ReloadInterval)
 			for {
-				select {
-				case <-t.C:
-				case <-ctx.Done():
-					return nil
-				}
 				if err := r.Watch(ctx); err != nil {
 					level.Warn(logger).Log("msg", "error reloading server TLS certificate",
 						"err", err)
 				} else {
+					return nil
+				}
+				select {
+				case <-t.C:
+				case <-ctx.Done():
 					return nil
 				}
 			}


### PR DESCRIPTION
We should try to reload a TLS cert immediately and wait/retry on error,
instead of waiting before the first attempt.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:feature
    - release-note:change
    - release-note:none

Unless you choose release-note:none, please add a release note.
-->
**Release Note Template (will be copied)**

```release-note:REPLACEME

```
