### PR TITLE
BUG 2041459: alertmanager: only load cfg when writing cfg

### DIFF
--- a/pkg/alertmanager/operator.go
+++ b/pkg/alertmanager/operator.go
@@ -867,11 +867,6 @@ receivers:
 		}
 	}
 
-	baseConfig, err := loadCfg(string(rawBaseConfig))
-	if err != nil {
-		return errors.Wrap(err, "base config from Secret could not be parsed")
-	}
-
 	// If no AlertmanagerConfig selectors are configured, the user wants to
 	// manage configuration themselves.
 	if am.Spec.AlertmanagerConfigSelector == nil {
@@ -885,6 +880,11 @@ receivers:
 			return errors.Wrap(err, "create or update generated config secret failed")
 		}
 		return nil
+	}
+
+	baseConfig, err := loadCfg(string(rawBaseConfig))
+	if err != nil {
+		return errors.Wrap(err, "base config from Secret could not be parsed")
 	}
 
 	amConfigs, err := c.selectAlertmanagerConfigs(ctx, am, store)

--- a/pkg/alertmanager/operator_test.go
+++ b/pkg/alertmanager/operator_test.go
@@ -857,11 +857,38 @@ func TestProvisionAlertmanagerConfiguration(t *testing.T) {
 		{
 			am: &monitoringv1.Alertmanager{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-user-config",
+					Name:      "invalid-user-config-in-secret-with-no-config-selector",
+					Namespace: "test",
+				},
+				Spec: monitoringv1.AlertmanagerSpec{
+					ConfigSecret:               "amconfig",
+					AlertmanagerConfigSelector: nil,
+				},
+			},
+			objects: []runtime.Object{
+				&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "amconfig",
+						Namespace: "test",
+					},
+					Data: map[string][]byte{
+						"alertmanager.yaml": []byte(`invalid`),
+					},
+				},
+			},
+			ok: true,
+		},
+		{
+			am: &monitoringv1.Alertmanager{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-user-config-provided-to-operator",
 					Namespace: "test",
 				},
 				Spec: monitoringv1.AlertmanagerSpec{
 					ConfigSecret: "amconfig",
+					AlertmanagerConfigSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"test": "test"},
+					},
 				},
 			},
 			objects: []runtime.Object{


### PR DESCRIPTION
Cherry-pick of https://github.com/prometheus-operator/prometheus-operator/pull/4333 with conflicts addressed 

Background
---
The operator can merge configuration when the
[`AlertmanagerConfigSelector`](https://github.com/prometheus-operator/prometheus-operator/blob/83fe36566f4e0894eb5ffcd2638a0f039a17bdeb/pkg/apis/monitoring/v1/types.go#L1547)
is defined. We are validating (using upstream alertmanager) and
parsing (using internal config) even if we don't need to load config in
memory since the user opted to manage the configuration via the secret.

This can cause problems where there is a missmatch between alertmanager
configuration and the operator internal amcfg struct, for example
prometheus-operator#4174.

Solution
---
Only validate the configuration from upstream `alertmanager` function,
and then only load the configuration in memory with the operators struct
when we need to write back to the secret.

As a cluster admin, I want to be able to pass arbitrary alertmanager
config via the secret, which goes unvalidated by the operator, so that I
can make use of latest alertmanager features without being concerned
about feature drift between the operator and alertmanager.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
