### PR TITLE
Bug 2037762: pkg/prometheus: Add validation for ScrapeTimeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/alecthomas/units v0.0.0-20210927113745-59d0afb8317a
+	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef
 	github.com/blang/semver/v4 v4.0.0
 	github.com/brancz/kube-rbac-proxy v0.11.0
 	github.com/docker/distribution v2.7.1+incompatible
@@ -44,7 +45,6 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/aws/aws-sdk-go v1.42.16 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/pkg/operator/validations.go
+++ b/pkg/operator/validations.go
@@ -16,6 +16,7 @@ package operator
 
 import (
 	"github.com/alecthomas/units"
+	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 )
 
@@ -32,5 +33,29 @@ func ValidateDurationField(durationField string) error {
 	if _, err := model.ParseDuration(durationField); err != nil {
 		return err
 	}
+	return nil
+}
+
+// CompareScrapeTimeoutToScrapeInterval validates value of scrapeTimeout based on scrapeInterval
+func CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval string) error {
+	var err error
+	var si, st model.Duration
+
+	// since default scrapeInterval set by operator is 30s
+	if scrapeInterval == "" {
+		scrapeInterval = "30s"
+	}
+
+	if si, err = model.ParseDuration(scrapeInterval); err != nil {
+		return errors.Wrapf(err, "invalid scrapeInterval %q", scrapeInterval)
+	}
+	if st, err = model.ParseDuration(scrapeTimeout); err != nil {
+		return errors.Wrapf(err, "invalid scrapeTimeout: %q", scrapeTimeout)
+	}
+
+	if st > si {
+		return errors.Errorf("scrapeTimeout %q greater than scrapeInterval %q", scrapeTimeout, scrapeInterval)
+	}
+
 	return nil
 }

--- a/pkg/prometheus/operator.go
+++ b/pkg/prometheus/operator.go
@@ -24,11 +24,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/asaskevich/govalidator"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/relabel"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -1795,6 +1798,26 @@ func (c *Operator) selectServiceMonitors(ctx context.Context, p *monitoringv1.Pr
 			if err = store.AddSafeAuthorizationCredentials(ctx, sm.GetNamespace(), endpoint.Authorization, smAuthKey); err != nil {
 				break
 			}
+
+			if err = validateScrapeIntervalAndTimeout(p, endpoint.Interval, endpoint.ScrapeTimeout); err != nil {
+				break
+			}
+
+			for _, rl := range endpoint.RelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
+			}
+
+			for _, rl := range endpoint.MetricRelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
+			}
 		}
 
 		if err != nil {
@@ -1894,6 +1917,26 @@ func (c *Operator) selectPodMonitors(ctx context.Context, p *monitoringv1.Promet
 			pmAuthKey := fmt.Sprintf("podMonitor/auth/%s/%s/%d", pm.GetNamespace(), pm.GetName(), i)
 			if err = store.AddSafeAuthorizationCredentials(ctx, pm.GetNamespace(), endpoint.Authorization, pmAuthKey); err != nil {
 				break
+			}
+
+			if err = validateScrapeIntervalAndTimeout(p, endpoint.Interval, endpoint.ScrapeTimeout); err != nil {
+				break
+			}
+
+			for _, rl := range endpoint.RelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
+			}
+
+			for _, rl := range endpoint.MetricRelabelConfigs {
+				if rl.Action != "" {
+					if err = validateRelabelConfig(*rl); err != nil {
+						break
+					}
+				}
 			}
 		}
 
@@ -2010,6 +2053,24 @@ func (c *Operator) selectProbes(ctx context.Context, p *monitoringv1.Prometheus,
 			continue
 		}
 
+		if err = validateScrapeIntervalAndTimeout(p, probe.Spec.Interval, probe.Spec.ScrapeTimeout); err != nil {
+			rejectFn(probe, err)
+			continue
+		}
+
+		for _, rl := range probe.Spec.MetricRelabelConfigs {
+			if rl.Action != "" {
+				if err = validateRelabelConfig(*rl); err != nil {
+					rejectFn(probe, err)
+					continue
+				}
+			}
+		}
+		if err = validateProberURL(probe.Spec.ProberSpec.URL); err != nil {
+			err := errors.Wrapf(err, "%s url specified in proberSpec is invalid, it should be of the format `hostname` or `hostname:port`", probe.Spec.ProberSpec.URL)
+			rejectFn(probe, err)
+			continue
+		}
 		res[probeName] = probe
 	}
 
@@ -2080,4 +2141,64 @@ func validateRemoteWriteSpec(spec monitoringv1.RemoteWriteSpec) error {
 	}
 
 	return nil
+}
+
+func validateRelabelConfig(rc monitoringv1.RelabelConfig) error {
+	relabelTarget := regexp.MustCompile(`^(?:(?:[a-zA-Z_]|\$(?:\{\w+\}|\w+))+\w*)+$`)
+
+	if _, err := relabel.NewRegexp(rc.Regex); err != nil {
+		return errors.Wrapf(err, "invalid regex %s for relabel configuration", rc.Regex)
+	}
+	if rc.Modulus == 0 && rc.Action == string(relabel.HashMod) {
+		return errors.Errorf("relabel configuration for hashmod requires non-zero modulus")
+	}
+	if (rc.Action == string(relabel.Replace) || rc.Action == string(relabel.HashMod)) && rc.TargetLabel == "" {
+		return errors.Errorf("relabel configuration for %s action needs targetLabel value", rc.Action)
+	}
+	if rc.Action == string(relabel.Replace) && !relabelTarget.MatchString(rc.TargetLabel) {
+		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+	}
+	if rc.Action == string(relabel.LabelMap) && !relabelTarget.MatchString(rc.Replacement) {
+		return errors.Errorf("%q is invalid 'replacement' for %s action", rc.Replacement, rc.Action)
+	}
+	if rc.Action == string(relabel.HashMod) && !model.LabelName(rc.TargetLabel).IsValid() {
+		return errors.Errorf("%q is invalid 'target_label' for %s action", rc.TargetLabel, rc.Action)
+	}
+
+	if rc.Action == string(relabel.LabelDrop) || rc.Action == string(relabel.LabelKeep) {
+		if len(rc.SourceLabels) != 0 ||
+			rc.TargetLabel != "" ||
+			rc.Modulus != uint64(0) ||
+			rc.Separator != "" ||
+			rc.Replacement != "" {
+			return errors.Errorf("%s action requires only 'regex', and no other fields", rc.Action)
+		}
+	}
+	return nil
+}
+
+func validateProberURL(url string) error {
+	hostPort := strings.Split(url, ":")
+
+	if !govalidator.IsHost(hostPort[0]) {
+		return errors.Errorf("invalid host: %q", hostPort[0])
+	}
+
+	// handling cases with url specified as host:port
+	if len(hostPort) > 1 {
+		if !govalidator.IsPort(hostPort[1]) {
+			return errors.Errorf("invalid port: %q", hostPort[1])
+		}
+	}
+	return nil
+}
+
+func validateScrapeIntervalAndTimeout(p *monitoringv1.Prometheus, scrapeInterval, scrapeTimeout string) error {
+	if scrapeTimeout == "" {
+		return nil
+	}
+	if scrapeInterval == "" {
+		scrapeInterval = p.Spec.ScrapeInterval
+	}
+	return operator.CompareScrapeTimeoutToScrapeInterval(scrapeTimeout, scrapeInterval)
 }

--- a/pkg/prometheus/operator_test.go
+++ b/pkg/prometheus/operator_test.go
@@ -15,6 +15,7 @@
 package prometheus
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -260,6 +261,296 @@ func TestValidateRemoteWriteConfig(t *testing.T) {
 			}
 			if err == nil && test.expectErr {
 				t.Fatalf("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func TestValidateRelabelConfig(t *testing.T) {
+	for _, tc := range []struct {
+		scenario      string
+		relabelConfig monitoringv1.RelabelConfig
+		expectedErr   bool
+	}{
+		// Test invalid regex expression
+		{
+			scenario: "Invalid regex",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Regex: "invalid regex)",
+			},
+			expectedErr: true,
+		},
+		// Test invalid target label
+		{
+			scenario: "invalid target label",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "replace",
+				TargetLabel: "l\\${3}",
+			},
+			expectedErr: true,
+		},
+		// Test empty target label for action replace
+		{
+			scenario: "empty target label for replace action",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "replace",
+				TargetLabel: "",
+			},
+			expectedErr: true,
+		},
+		// Test empty target label for action hashmod
+		{
+			scenario: "empty target label for hashmod action",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "hashmod",
+				TargetLabel: "",
+			},
+			expectedErr: true,
+		},
+		// Test invalid hashmod relabel config
+		{
+			scenario: "invalid hashmod config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"instance"},
+				Action:       "hashmod",
+				Modulus:      0,
+				TargetLabel:  "__tmp_hashmod",
+			},
+			expectedErr: true,
+		},
+		// Test invalid labelmap relabel config
+		{
+			scenario: "invalid labelmap config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action: "labelmap",
+				Regex:  "__meta_kubernetes_service_label_(.+)",
+			},
+			expectedErr: true,
+		},
+		// Test valid labelmap relabel config
+		{
+			scenario: "valid labelmap config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action:      "labelmap",
+				Regex:       "__meta_kubernetes_service_label_(.+)",
+				Replacement: "k8s_$1",
+			},
+		},
+		// Test invalid labelkeep relabel config
+		{
+			scenario: "invalid labelkeep config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"instance"},
+				Action:       "labelkeep",
+				TargetLabel:  "__tmp_labelkeep",
+			},
+			expectedErr: true,
+		},
+		// Test valid labelkeep relabel config
+		{
+			scenario: "valid labelkeep config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action: "labelkeep",
+			},
+		},
+		// Test valid labeldrop relabel config
+		{
+			scenario: "valid labeldrop config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				Action: "labeldrop",
+				Regex:  "replica",
+			},
+		},
+		// Test valid relabel config
+		{
+			scenario: "valid hashmod config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"instance"},
+				Action:       "hashmod",
+				Modulus:      10,
+				TargetLabel:  "__tmp_hashmod",
+			},
+		},
+		// Test valid relabel config
+		{
+			scenario: "valid replace config",
+			relabelConfig: monitoringv1.RelabelConfig{
+				SourceLabels: []string{"__address__"},
+				Action:       "replace",
+				Regex:        "([^:]+)(?::\\d+)?",
+				Replacement:  "$1:80",
+				TargetLabel:  "__address__",
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("case %s", tc.scenario), func(t *testing.T) {
+			err := validateRelabelConfig(tc.relabelConfig)
+			if err != nil && !tc.expectedErr {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if err == nil && tc.expectedErr {
+				t.Fatalf("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func TestValidateProberUrl(t *testing.T) {
+	for _, tc := range []struct {
+		scenario    string
+		proberSpec  monitoringv1.ProberSpec
+		expectedErr bool
+	}{
+		{
+			scenario: "url starting with http",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "http://blackbox-exporter.example.com",
+			},
+			expectedErr: true,
+		},
+		{
+			scenario: "url starting with https",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "https://blackbox-exporter.example.com",
+			},
+			expectedErr: true,
+		},
+		{
+			scenario: "url starting with ftp",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "ftp://fileserver.com",
+			},
+			expectedErr: true,
+		},
+		{
+			scenario: "ip address as prober url",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "192.168.178.3",
+			},
+		},
+		{
+			scenario: "ip address:port as prober url",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "192.168.178.3:9090",
+			},
+		},
+		{
+			scenario: "dnsname as prober url",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "blackbox-exporter.example.com",
+			},
+		},
+		{
+			scenario: "dnsname:port as prober url",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "blackbox-exporter.example.com:8080",
+			},
+		},
+		{
+			scenario: "hostname as prober url",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "localhost",
+			},
+		},
+		{
+			scenario: "hostname starting with a digit as prober url",
+			proberSpec: monitoringv1.ProberSpec{
+				URL: "12-exporter.example.com",
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("case %s %s", tc.scenario, tc.proberSpec.URL), func(t *testing.T) {
+			err := validateProberURL(tc.proberSpec.URL)
+			if err != nil && !tc.expectedErr {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+			if err == nil && tc.expectedErr {
+				t.Fatalf("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func TestValidateScrapeIntervalAndTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		scenario    string
+		prometheus  monitoringv1.Prometheus
+		smSpec      monitoringv1.ServiceMonitorSpec
+		expectedErr bool
+	}{
+		{
+			scenario: "scrape interval and timeout specified at service monitor spec but invalid #1",
+			smSpec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						Interval:      "30s",
+						ScrapeTimeout: "45s",
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			scenario: "scrape interval and timeout specified at service monitor spec but invalid #2",
+			smSpec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						Interval:      "30 s",
+						ScrapeTimeout: "10s",
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			scenario: "scrape interval and timeout specified at service monitor spec are valid",
+			smSpec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						Interval:      "15s",
+						ScrapeTimeout: "10s",
+					},
+				},
+			},
+		},
+		{
+			scenario: "only scrape timeout specified at service monitor spec but invalid compared to global scrapeInterval",
+			prometheus: monitoringv1.Prometheus{
+				Spec: monitoringv1.PrometheusSpec{
+					ScrapeInterval: "15s",
+				},
+			},
+			smSpec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						ScrapeTimeout: "20s",
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			scenario: "only scrape timeout specified at service monitor spec but invalid compared to default global scrapeInterval",
+			smSpec: monitoringv1.ServiceMonitorSpec{
+				Endpoints: []monitoringv1.Endpoint{
+					{
+						ScrapeTimeout: "60s",
+					},
+				},
+			},
+			expectedErr: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("case %s", tc.scenario), func(t *testing.T) {
+			for _, endpoint := range tc.smSpec.Endpoints {
+				err := validateScrapeIntervalAndTimeout(&tc.prometheus, endpoint.Interval, endpoint.ScrapeTimeout)
+				t.Logf("err %v", err)
+				if err != nil && !tc.expectedErr {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+				if err == nil && tc.expectedErr {
+					t.Fatalf("expected an error, got nil")
+				}
 			}
 		})
 	}

--- a/pkg/prometheus/promcfg.go
+++ b/pkg/prometheus/promcfg.go
@@ -25,12 +25,11 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/prometheus-operator/prometheus-operator/pkg/assets"
 	"github.com/prometheus-operator/prometheus-operator/pkg/operator"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -251,6 +250,9 @@ func validateConfigInputs(p *v1.Prometheus) error {
 	if p.Spec.ScrapeTimeout != "" {
 		if err := operator.ValidateDurationField(p.Spec.ScrapeTimeout); err != nil {
 			return errors.Wrap(err, "invalid scrapeTimeout value specified")
+		}
+		if err := operator.CompareScrapeTimeoutToScrapeInterval(p.Spec.ScrapeTimeout, p.Spec.ScrapeInterval); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
This change adds validation for scrapeTimeout to avoid specifying
higher value than scrapeInterval at prometheus, servicemonitor, podmonitor and probe levels

cherry-pick of https://github.com/prometheus-operator/prometheus-operator/pull/4491 to fix https://bugzilla.redhat.com/show_bug.cgi?id=2037762

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
