### PR TITLE
Bug 2079679: pkg/prometheus: fix curl exec probe

### DIFF
--- a/pkg/operator/prober.go
+++ b/pkg/operator/prober.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"fmt"
+)
+
+func CurlProber(u string) string {
+	return fmt.Sprintf("curl --fail %s", u)
+}
+
+func WgetProber(u string) string {
+	return fmt.Sprintf("wget -q -O /dev/null %s", u)
+}

--- a/pkg/operator/prober_test.go
+++ b/pkg/operator/prober_test.go
@@ -1,0 +1,82 @@
+// Copyright 2022 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestProbers(t *testing.T) {
+	for _, tc := range []struct {
+		code int
+		err  bool
+	}{
+		{
+			code: http.StatusOK,
+			err:  false,
+		},
+		{
+			code: http.StatusServiceUnavailable,
+			err:  true,
+		},
+	} {
+		for _, p := range []struct {
+			name   string
+			prober func(string) string
+		}{
+			{
+				name:   "curl",
+				prober: CurlProber,
+			},
+			{
+				name:   "wget",
+				prober: WgetProber,
+			},
+		} {
+			t.Run(fmt.Sprintf("%d-%s", tc.code, p.name), func(t *testing.T) {
+				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tc.code)
+				}))
+				defer ts.Close()
+
+				args := strings.Split(p.prober(ts.URL), " ")
+				if _, err := exec.LookPath(args[0]); err != nil {
+					t.Skipf("%s: %v", args[0], err)
+				}
+
+				cmd := exec.Command(args[0], args[1:]...)
+				b, err := cmd.CombinedOutput()
+				if tc.err {
+					if err == nil {
+						t.Logf("%s: %s", strings.Join(args, " "), string(b))
+						t.Fatal("expecting error but got nil")
+					}
+					return
+				}
+
+				if err != nil {
+					t.Logf("%s: %s", strings.Join(args, " "), string(b))
+					t.Fatalf("expecting no error but got %v", err)
+				}
+			})
+		}
+
+	}
+}

--- a/pkg/prometheus/statefulset.go
+++ b/pkg/prometheus/statefulset.go
@@ -631,21 +631,31 @@ func makeStatefulSetSpec(p monitoringv1.Prometheus, c *operator.Config, shard in
 		probePath = path.Clean(webRoutePrefix + probePath)
 		handler := v1.ProbeHandler{}
 		if p.Spec.ListenLocal {
+			probeURL := url.URL{
+				Scheme: "http",
+				Host:   "localhost:9090",
+				Path:   probePath,
+			}
 			handler.Exec = &v1.ExecAction{
 				Command: []string{
 					"sh",
 					"-c",
-					fmt.Sprintf(`if [ -x "$(command -v curl)" ]; then exec curl %[1]s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %[1]s; else exit 1; fi`, fmt.Sprintf("http://localhost:9090%s", probePath)),
+					fmt.Sprintf(
+						`if [ -x "$(command -v curl)" ]; then exec %s; elif [ -x "$(command -v wget)" ]; then exec %s; else exit 1; fi`,
+						operator.CurlProber(probeURL.String()),
+						operator.WgetProber(probeURL.String()),
+					),
 				},
 			}
-		} else {
-			handler.HTTPGet = &v1.HTTPGetAction{
-				Path: probePath,
-				Port: intstr.FromString(p.Spec.PortName),
-			}
-			if p.Spec.Web != nil && p.Spec.Web.TLSConfig != nil && version.GTE(semver.MustParse("2.24.0")) {
-				handler.HTTPGet.Scheme = v1.URISchemeHTTPS
-			}
+			return handler
+		}
+
+		handler.HTTPGet = &v1.HTTPGetAction{
+			Path: probePath,
+			Port: intstr.FromString(p.Spec.PortName),
+		}
+		if p.Spec.Web != nil && p.Spec.Web.TLSConfig != nil && version.GTE(semver.MustParse("2.24.0")) {
+			handler.HTTPGet.Scheme = v1.URISchemeHTTPS
 		}
 		return handler
 	}

--- a/pkg/prometheus/statefulset_test.go
+++ b/pkg/prometheus/statefulset_test.go
@@ -474,7 +474,7 @@ func TestListenLocal(t *testing.T) {
 				Command: []string{
 					`sh`,
 					`-c`,
-					fmt.Sprintf(`if [ -x "$(command -v curl)" ]; then exec curl %[1]s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %[1]s; else exit 1; fi`, fmt.Sprintf("http://localhost:9090%s", probePath)),
+					fmt.Sprintf(`if [ -x "$(command -v curl)" ]; then exec curl --fail %[1]s; elif [ -x "$(command -v wget)" ]; then exec wget -q -O /dev/null %[1]s; else exit 1; fi`, fmt.Sprintf("http://localhost:9090%s", probePath)),
 				},
 			},
 		}


### PR DESCRIPTION
Cherry-pick of https://github.com/prometheus-operator/prometheus-operator/commit/ceac7c9c4b436f37fca2e718153b724ee92be9c9 to avoid simultaneous restarts of Prometheus pods.

By default, the `curl` command returns with a zero exit code (success)
if the endpoint doesn't reply with a 2xx status code. As a result, the
readiness probe would succeed as soon as the Prometheus web server is
ready to respond while `/-/ready` may return "503 Service Not Available"
(e.g. the server hasn't finished loading the TSDB). During a
StatefulSet update with a 2 (or more) replicas, it means that the
StatefulSet controller may recreate the next pod while the last updated
pod hasn't finished its initialization, leading to a service disruption.

The issue is fixed by adding the `--fail` flag to the command. The man
page warns that it may still return success in some edge cases (such as
when authentication is involved) which shouldn't happen here. The
alternative would be to output the returned status code and check the
with more shell scripting but I fear that it's going to be more brittle.

Note that the issue only affects Prometheus objects with
`spec.listenLocal: true` and that 'wget' probes were unaffected.