### PR TITLE
OCPBUGS-7458: Fixes ThanoRuler StatefulSet re-creation bug

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -15,6 +15,7 @@
 package operator
 
 import (
+	"sort"
 	"strings"
 
 	"k8s.io/client-go/rest"
@@ -91,6 +92,16 @@ func (labels *Labels) Set(value string) error {
 	(*labels).LabelsMap = m
 	(*labels).LabelsString = value
 	return nil
+}
+
+// Returns an arrary with the keys of the label map sorted
+func (labels *Labels) SortedKeys() []string {
+	keys := make([]string, 0, len(labels.LabelsMap))
+	for key := range labels.LabelsMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 type Namespaces struct {

--- a/pkg/thanos/statefulset.go
+++ b/pkg/thanos/statefulset.go
@@ -205,8 +205,9 @@ func makeStatefulSetSpec(tr *monitoringv1.ThanosRuler, config Config, ruleConfig
 	}
 
 	trCLIArgs = append(trCLIArgs, fmt.Sprintf(`--label=%s="$(POD_NAME)"`, defaultReplicaLabelName))
-	for k, v := range tr.Spec.Labels {
-		trCLIArgs = append(trCLIArgs, fmt.Sprintf(`--label=%s="%s"`, k, v))
+	labels := operator.Labels{LabelsMap: tr.Spec.Labels}
+	for _, k := range labels.SortedKeys() {
+		trCLIArgs = append(trCLIArgs, fmt.Sprintf(`--label=%s="%s"`, k, labels.LabelsMap[k]))
 	}
 
 	trCLIArgs = append(trCLIArgs, fmt.Sprintf("--alert.label-drop=%s", defaultReplicaLabelName))

--- a/pkg/thanos/statefulset_test.go
+++ b/pkg/thanos/statefulset_test.go
@@ -17,7 +17,6 @@ package thanos
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -477,86 +476,97 @@ func TestLabelsAndAlertDropLabels(t *testing.T) {
 	alertDropLabelPrefix := "--alert.label-drop="
 
 	tests := []struct {
+		Name                    string
 		Labels                  map[string]string
 		AlertDropLabels         []string
 		ExpectedLabels          []string
 		ExpectedAlertDropLabels []string
 	}{
 		{
+			Name:                    "thanos_ruler_replica-is-set",
 			Labels:                  nil,
 			AlertDropLabels:         nil,
 			ExpectedLabels:          []string{`thanos_ruler_replica="$(POD_NAME)"`},
 			ExpectedAlertDropLabels: []string{"thanos_ruler_replica"},
 		},
 		{
+			Name:                    "alert-drop-labels-are-set",
 			Labels:                  nil,
 			AlertDropLabels:         []string{"test"},
 			ExpectedLabels:          []string{`thanos_ruler_replica="$(POD_NAME)"`},
 			ExpectedAlertDropLabels: []string{"thanos_ruler_replica", "test"},
 		},
 		{
+			Name: "labels-are-set",
 			Labels: map[string]string{
 				"test": "test",
 			},
 			AlertDropLabels:         nil,
-			ExpectedLabels:          []string{`test="test"`, `thanos_ruler_replica="$(POD_NAME)"`},
+			ExpectedLabels:          []string{`thanos_ruler_replica="$(POD_NAME)"`, `test="test"`},
 			ExpectedAlertDropLabels: []string{"thanos_ruler_replica"},
 		},
 		{
+			Name: "both-alert-drop-labels-and-labels-are-set",
 			Labels: map[string]string{
 				"test": "test",
 			},
 			AlertDropLabels:         []string{"test"},
-			ExpectedLabels:          []string{`test="test"`, `thanos_ruler_replica="$(POD_NAME)"`},
+			ExpectedLabels:          []string{`thanos_ruler_replica="$(POD_NAME)"`, `test="test"`},
 			ExpectedAlertDropLabels: []string{"thanos_ruler_replica", "test"},
 		},
 		{
+			Name: "assert-labels-order-is-constant",
 			Labels: map[string]string{
 				"thanos_ruler_replica": "$(POD_NAME)",
 				"test":                 "test",
+				"test4":                "test4",
+				"test1":                "test1",
+				"test2":                "test2",
+				"test3":                "test3",
+				"foo":                  "bar",
+				"bob":                  "alice",
 			},
-			AlertDropLabels:         []string{"test", "aaa"},
-			ExpectedLabels:          []string{`test="test"`, `thanos_ruler_replica="$(POD_NAME)"`, `thanos_ruler_replica="$(POD_NAME)"`},
-			ExpectedAlertDropLabels: []string{"thanos_ruler_replica", "test", "aaa"},
+			AlertDropLabels:         []string{"test", "aaa", "foo", "bar", "foo1", "foo2", "foo3"},
+			ExpectedLabels:          []string{`thanos_ruler_replica="$(POD_NAME)"`, `bob="alice"`, `foo="bar"`, `test="test"`, `test1="test1"`, `test2="test2"`, `test3="test3"`, `test4="test4"`, `thanos_ruler_replica="$(POD_NAME)"`},
+			ExpectedAlertDropLabels: []string{"thanos_ruler_replica", "test", "aaa", "foo", "bar", "foo1", "foo2", "foo3"},
 		},
 	}
 	for _, tc := range tests {
-		actualLabels := []string{}
-		actualDropLabels := []string{}
-		sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
-			ObjectMeta: metav1.ObjectMeta{},
-			Spec: monitoringv1.ThanosRulerSpec{
-				QueryEndpoints:  emptyQueryEndpoints,
-				Labels:          tc.Labels,
-				AlertDropLabels: tc.AlertDropLabels,
-			},
-		}, defaultTestConfig, nil, "")
-		if err != nil {
-			t.Fatalf("Unexpected error while making StatefulSet: %v", err)
-		}
-
-		ruler := sset.Spec.Template.Spec.Containers[0]
-		if ruler.Name != "thanos-ruler" {
-			t.Fatalf("Expected 1st containers to be thanos-ruler, got %s", ruler.Name)
-		}
-
-		for _, arg := range ruler.Args {
-			if strings.HasPrefix(arg, labelPrefix) {
-				actualLabels = append(actualLabels, strings.TrimPrefix(arg, labelPrefix))
-			} else if strings.HasPrefix(arg, alertDropLabelPrefix) {
-				actualDropLabels = append(actualDropLabels, strings.TrimPrefix(arg, alertDropLabelPrefix))
+		t.Run(tc.Name, func(t *testing.T) {
+			actualLabels := []string{}
+			actualDropLabels := []string{}
+			sset, err := makeStatefulSet(&monitoringv1.ThanosRuler{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: monitoringv1.ThanosRulerSpec{
+					QueryEndpoints:  emptyQueryEndpoints,
+					Labels:          tc.Labels,
+					AlertDropLabels: tc.AlertDropLabels,
+				},
+			}, defaultTestConfig, nil, "")
+			if err != nil {
+				t.Fatalf("Unexpected error while making StatefulSet: %v", err)
 			}
-		}
-		sort.Slice(actualLabels, func(i, j int) bool {
-			return actualLabels[i] < actualLabels[j]
-		})
-		if !reflect.DeepEqual(actualLabels, tc.ExpectedLabels) {
-			t.Fatal("label sets mismatch")
-		}
 
-		if !reflect.DeepEqual(actualDropLabels, tc.ExpectedAlertDropLabels) {
-			t.Fatal("alert drop label sets mismatch")
-		}
+			ruler := sset.Spec.Template.Spec.Containers[0]
+			if ruler.Name != "thanos-ruler" {
+				t.Fatalf("Expected 1st containers to be thanos-ruler, got %s", ruler.Name)
+			}
+
+			for _, arg := range ruler.Args {
+				if strings.HasPrefix(arg, labelPrefix) {
+					actualLabels = append(actualLabels, strings.TrimPrefix(arg, labelPrefix))
+				} else if strings.HasPrefix(arg, alertDropLabelPrefix) {
+					actualDropLabels = append(actualDropLabels, strings.TrimPrefix(arg, alertDropLabelPrefix))
+				}
+			}
+			if !reflect.DeepEqual(actualLabels, tc.ExpectedLabels) {
+				t.Fatalf("labels mismatch expected %v but got %v", tc.ExpectedLabels, actualLabels)
+			}
+
+			if !reflect.DeepEqual(actualDropLabels, tc.ExpectedAlertDropLabels) {
+				t.Fatalf("alert drop labels mismatch, expected %v, but got %v", tc.ExpectedAlertDropLabels, actualDropLabels)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Description

Issue: https://issues.redhat.com/browse/OCPBUGS-7458


## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
