### PR TITLE
OCPBUGS-22946: fix: remove verbose logging admission-webhook

### DIFF
--- a/cmd/admission-webhook/main.go
+++ b/cmd/admission-webhook/main.go
@@ -169,8 +169,8 @@ func newSrv(logger log.Logger, tlsConf *tls.Config) *srv {
 	mux.Handle("/metrics", promhttp.HandlerFor(r, promhttp.HandlerOpts{}))
 
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"status":"up"}`))
 		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"up"}`))
 	})
 
 	httpServer := http.Server{


### PR DESCRIPTION
After disabling HTTP2 connections by default in #6028 started seeing verbose logging in admission webhook pods like:

`ts=2023-11-06T01:50:34.601774794Z caller=stdlib.go:105 caller=server.go:3215 msg="http: superfluous response.WriteHeader call from main.newSrv.func1 (main.go:173)" `

Go doc says If WriteHeader is not called explicitly, the first call to Write will trigger an implicit
WriteHeader(http.StatusOK).

This fix is to change the order of the method invocation so log doesn't complain about this

Signed-off-by: Jayapriya Pai <slashpai9@gmail.com>
(cherry picked from commit 374f4b3d0c58d23318b4f1fd4e0c25b057d34062)

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
