### PR TITLE
OCPBUGS-28251: fix: convert `continue` field between v1beta1 and v1alpha1

### DIFF
--- a/pkg/apis/monitoring/v1beta1/conversion_from.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_from.go
@@ -32,6 +32,7 @@ func convertRouteFrom(in *v1alpha1.Route) (*Route, error) {
 
 	out := &Route{
 		Receiver:            in.Receiver,
+		Continue:            in.Continue,
 		GroupBy:             in.GroupBy,
 		GroupWait:           in.GroupWait,
 		GroupInterval:       in.GroupInterval,

--- a/pkg/apis/monitoring/v1beta1/conversion_to.go
+++ b/pkg/apis/monitoring/v1beta1/conversion_to.go
@@ -32,6 +32,7 @@ func convertRouteTo(in *Route) (*v1alpha1.Route, error) {
 
 	out := &v1alpha1.Route{
 		Receiver:            in.Receiver,
+		Continue:            in.Continue,
 		GroupBy:             in.GroupBy,
 		GroupWait:           in.GroupWait,
 		GroupInterval:       in.GroupInterval,

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/conversion_from.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/conversion_from.go
@@ -32,6 +32,7 @@ func convertRouteFrom(in *v1alpha1.Route) (*Route, error) {
 
 	out := &Route{
 		Receiver:            in.Receiver,
+		Continue:            in.Continue,
 		GroupBy:             in.GroupBy,
 		GroupWait:           in.GroupWait,
 		GroupInterval:       in.GroupInterval,

--- a/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/conversion_to.go
+++ b/vendor/github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1beta1/conversion_to.go
@@ -32,6 +32,7 @@ func convertRouteTo(in *Route) (*v1alpha1.Route, error) {
 
 	out := &v1alpha1.Route{
 		Receiver:            in.Receiver,
+		Continue:            in.Continue,
 		GroupBy:             in.GroupBy,
 		GroupWait:           in.GroupWait,
 		GroupInterval:       in.GroupInterval,


### PR DESCRIPTION
Cherry-pick of https://github.com/prometheus-operator/prometheus-operator/pull/6282