### PR TITLE
[release-4.15] OCPBUGS-36719: add proxyURL validation for smon,pmon and probe

### DIFF
--- a/pkg/prometheus/resource_selector_test.go
+++ b/pkg/prometheus/resource_selector_test.go
@@ -488,6 +488,20 @@ func TestSelectProbes(t *testing.T) {
 			selected: true,
 		},
 		{
+			scenario: "invalid proxyurl",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.ProxyURL = "http://xxx-${dev}.svc.cluster.local:80"
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid proxyurl",
+			updateSpec: func(ps *monitoringv1.ProbeSpec) {
+				ps.ProberSpec.ProxyURL = "123-proxy.example.com"
+			},
+			selected: true,
+		},
+		{
 			scenario: "valid metric relabeling config",
 			updateSpec: func(ps *monitoringv1.ProbeSpec) {
 				ps.MetricRelabelConfigs = []*monitoringv1.RelabelConfig{
@@ -763,6 +777,24 @@ func TestSelectServiceMonitors(t *testing.T) {
 			},
 			selected: false,
 		},
+		{
+			scenario: "invalid proxyurl",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					ProxyURL: ptr.To("http://xxx-${dev}.svc.cluster.local:80"),
+				})
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid proxyurl",
+			updateSpec: func(sm *monitoringv1.ServiceMonitorSpec) {
+				sm.Endpoints = append(sm.Endpoints, monitoringv1.Endpoint{
+					ProxyURL: ptr.To("http://proxy.svc.cluster.local:80"),
+				})
+			},
+			selected: true,
+		},
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {
 			rs := NewResourceSelector(
@@ -862,6 +894,24 @@ func TestSelectPodMonitors(t *testing.T) {
 				})
 			},
 			selected: false,
+		},
+		{
+			scenario: "invalid proxyurl",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					ProxyURL: ptr.To("http://xxx-${dev}.svc.cluster.local:80"),
+				})
+			},
+			selected: false,
+		},
+		{
+			scenario: "valid proxyurl",
+			updateSpec: func(pm *monitoringv1.PodMonitorSpec) {
+				pm.PodMetricsEndpoints = append(pm.PodMetricsEndpoints, monitoringv1.PodMetricsEndpoint{
+					ProxyURL: ptr.To("http://proxy.svc.cluster.local:80"),
+				})
+			},
+			selected: true,
 		},
 	} {
 		t.Run(tc.scenario, func(t *testing.T) {


### PR DESCRIPTION
If a user specify a non-parsable proxyUrl it was not validated/rejected but will break reloading and restarting of Prometheus due to possible invalid syntax.

This commit adds validation and rejects the invalid ones

Manual cherry-pick of prometheus-operator/prometheus-operator#6464

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
