### PR TITLE
DONOTMERGE: fix(reloader): explicitly watch the config file parent directory

### DIFF
--- a/pkg/operator/config_reloader.go
+++ b/pkg/operator/config_reloader.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"slices"
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"
@@ -264,6 +265,13 @@ func CreateConfigReloader(name string, options ...ReloaderOption) v1.Container {
 
 	if len(configReloader.configFile) > 0 {
 		args = append(args, fmt.Sprintf("--config-file=%s", configReloader.configFile))
+		// The underlying fsnotify library used by the reloader does not recommend watching individual files.
+		// For example, atomic file updates will make the file watcher obsolete. Watch the dir instead.
+		// See https://github.com/fsnotify/fsnotify/blob/a9bc2e01792f868516acf80817f7d7d7b3315409/README.md?plain=1#L128
+		confDir := configReloader.configFile
+		if !slices.Contains(configReloader.watchedDirectories, confDir) {
+			configReloader.watchedDirectories = append(configReloader.watchedDirectories, confDir)
+		}
 	}
 
 	if len(configReloader.configEnvsubstFile) > 0 {

--- a/pkg/prometheus/common.go
+++ b/pkg/prometheus/common.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"slices"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -328,6 +329,12 @@ func BuildConfigReloader(
 ) v1.Container {
 	cpf := p.GetCommonPrometheusFields()
 
+	// The underlying fsnotify library used by the reloader does not recommend watching individual files.
+	// For example, atomic file updates will make the file watcher obsolete. Watch the dir instead.
+	// See https://github.com/fsnotify/fsnotify/blob/a9bc2e01792f868516acf80817f7d7d7b3315409/README.md?plain=1#L128
+	if !slices.Contains(watchedDirectories, ConfDir) {
+		watchedDirectories = append(watchedDirectories, ConfDir)
+	}
 	reloaderOptions := []operator.ReloaderOption{
 		operator.ReloaderConfig(c.ReloaderConfig),
 		operator.LogFormat(cpf.LogFormat),


### PR DESCRIPTION
as the underlying fsnotify library used by the reloader does not recommend watching individual files since it is easy to misuse. See https://github.com/fsnotify/fsnotify/blob/a9bc2e01792f868516acf80817f7d7d7b3315409/README.md?plain=1#L128

For example, atomic file updates will render the initial file watcher obsolete. That watcher will only receive the first DELETE and then stop sending any events, causing the reloader to fall back to defaultWatchInterval (3 minutes).

kubelet updates the ConfigMap/Secret mounted files atomically using https://pkg.go.dev/k8s.io/kubernetes/pkg/volume/util#AtomicWriter

Because the operator is responsible for defining config file mounting, I suppose no other files exist in the parent directory that might trigger unneeded events.

Also, watching the config file's parent directory will catch events corresponding to kubelet's AtomicWriter  manipulations on symlinks and modifications to the timestamped directories which contain the various actual config file versions.

Given that, watching the entire parent directory may result in multiple events at once, but the reloader is able to smooth them out.

Because this "bug" has been around for a long time, I'm not sure about the consequences; perhaps some setups might not be able to cope with this acceleration of the reconciliation loop, but I'm sure this will be a significant time saver for a lot of users and "wait for config to get applied" tests/checks.

Maybe we should also think about whether to want/can teach the reloader to handle this on its side.

fixes https://github.com/prometheus-operator/prometheus-operator/issues/5408

Signed-off-by: machine424 <ayoubmrini424@gmail.com>
(cherry picked from commit 4c28682bc7a19bc3509dd0f8955595251317aeba)

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [Prometheus-Operator testing guidelines](../TESTING.md) for recommendations about automated tests.

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
